### PR TITLE
Update to .NET 4.6.1 and remove unused usings

### DIFF
--- a/GamePipe/App.config
+++ b/GamePipe/App.config
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
-    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
+    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net"/>
   </configSections>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
   </startup>
   <log4net>
     <appender name="ConsoleAppender" type="log4net.Appender.ConsoleAppender">
@@ -38,10 +38,8 @@
   <system.serviceModel>
     <!--https://msdn.microsoft.com/en-us/library/ms752250%28v=vs.110%29.aspx-->
     <services>
-      <service behaviorConfiguration="GameProviderServiceBehavior"
-        name="GamePipeService.GameProviderService">
-        <endpoint address="" binding="netTcpBinding" name="InfoProvider"
-          contract="GamePipeLib.Interfaces.IAppProvider" />
+      <service behaviorConfiguration="GameProviderServiceBehavior" name="GamePipeService.GameProviderService">
+        <endpoint address="" binding="netTcpBinding" name="InfoProvider" contract="GamePipeLib.Interfaces.IAppProvider"/>
       </service>
     </services>
     <behaviors>

--- a/GamePipe/App.xaml.cs
+++ b/GamePipe/App.xaml.cs
@@ -3,14 +3,7 @@
 * Distributed under the GNU GPL v2. For full terms see the file LICENSE.txt
 */
 using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Data;
-using System.Linq;
-using System.Threading.Tasks;
 using System.Windows;
-using log4net;
-using log4net.Config;
 
 namespace GamePipe
 {

--- a/GamePipe/Converters/EqualityToBooleanConverter.cs
+++ b/GamePipe/Converters/EqualityToBooleanConverter.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Data;
 
 namespace GamePipe.Converters

--- a/GamePipe/Converters/TransferBaseToViewModelConverter.cs
+++ b/GamePipe/Converters/TransferBaseToViewModelConverter.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Data;
 using GamePipe.ViewModel;
 

--- a/GamePipe/GamePipe.csproj
+++ b/GamePipe/GamePipe.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>GamePipe</RootNamespace>
     <AssemblyName>GamePipe</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
@@ -46,17 +46,13 @@
       <HintPath>..\packages\log4net.2.0.5\lib\net45-full\log4net.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
-    <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Xaml">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>

--- a/GamePipe/MainWindow.xaml.cs
+++ b/GamePipe/MainWindow.xaml.cs
@@ -2,22 +2,12 @@
 * Copyright (c) 2016 Joseph Shaw
 * Distributed under the GNU GPL v2. For full terms see the file LICENSE.txt
 */
-using System;
-using System.Collections.Generic;
+
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Diagnostics;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
-using System.ServiceModel;
 
 namespace GamePipe
 {

--- a/GamePipe/Properties/AssemblyInfo.cs
+++ b/GamePipe/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/GamePipe/View/FriendView.xaml.cs
+++ b/GamePipe/View/FriendView.xaml.cs
@@ -3,19 +3,9 @@
 * Distributed under the GNU GPL v2. For full terms see the file LICENSE.txt
 */
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 using GamePipe.ViewModel;
 
 namespace GamePipe.View

--- a/GamePipe/View/GameView.xaml.cs
+++ b/GamePipe/View/GameView.xaml.cs
@@ -2,20 +2,9 @@
 * Copyright (c) 2016 Joseph Shaw
 * Distributed under the GNU GPL v2. For full terms see the file LICENSE.txt
 */
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
 namespace GamePipe.View
 {

--- a/GamePipe/View/LibraryCardView.xaml.cs
+++ b/GamePipe/View/LibraryCardView.xaml.cs
@@ -2,20 +2,10 @@
 * Copyright (c) 2016 Joseph Shaw
 * Distributed under the GNU GPL v2. For full terms see the file LICENSE.txt
 */
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 using GamePipe.ViewModel;
 
 namespace GamePipe.View

--- a/GamePipe/View/LocalDriveView.xaml.cs
+++ b/GamePipe/View/LocalDriveView.xaml.cs
@@ -1,17 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+﻿using System.Windows.Controls;
 
 namespace GamePipe.View
 {

--- a/GamePipe/View/SteamLibraryView.xaml.cs
+++ b/GamePipe/View/SteamLibraryView.xaml.cs
@@ -3,19 +3,9 @@
 * Distributed under the GNU GPL v2. For full terms see the file LICENSE.txt
 */
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 using GamePipe.ViewModel;
 
 namespace GamePipe.View

--- a/GamePipe/ViewModel/FriendViewModel.cs
+++ b/GamePipe/ViewModel/FriendViewModel.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using GamePipeLib.Model.Steam;
 using GamePipeLib.Interfaces;

--- a/GamePipe/ViewModel/GameSortMode.cs
+++ b/GamePipe/ViewModel/GameSortMode.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace GamePipe.ViewModel
+﻿namespace GamePipe.ViewModel
 {
     public enum GameSortMode
     {

--- a/GamePipe/ViewModel/GameViewModel.cs
+++ b/GamePipe/ViewModel/GameViewModel.cs
@@ -3,14 +3,8 @@
 * Distributed under the GNU GPL v2. For full terms see the file LICENSE.txt
 */
 
-using Microsoft.VisualBasic;
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Data;
 using System.Diagnostics;
-using System.IO;
-using System.Windows.Input;
 using GamePipeLib.Model.Steam;
 using GamePipeLib.Interfaces;
 

--- a/GamePipe/ViewModel/RelayCommand.cs
+++ b/GamePipe/ViewModel/RelayCommand.cs
@@ -2,11 +2,8 @@
 * Copyright (c) 2016 Joseph Shaw
 * Distributed under the GNU GPL v2. For full terms see the file LICENSE.txt
 */
-using Microsoft.VisualBasic;
+
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Data;
 using System.Diagnostics;
 using System.Windows.Input;
 

--- a/GamePipe/ViewModel/RootSteamViewModel.cs
+++ b/GamePipe/ViewModel/RootSteamViewModel.cs
@@ -2,13 +2,8 @@
 * Copyright (c) 2016 Joseph Shaw
 * Distributed under the GNU GPL v2. For full terms see the file LICENSE.txt
 */
-using Microsoft.VisualBasic;
+
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Data;
-using System.Diagnostics;
-using System.Text.RegularExpressions;
 using System.IO;
 using System.Collections.ObjectModel;
 using GamePipeLib.Model.Steam;

--- a/GamePipe/ViewModel/SteamLibraryViewModel.cs
+++ b/GamePipe/ViewModel/SteamLibraryViewModel.cs
@@ -5,8 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.IO;
 using GamePipeLib.Model.Steam;
 using GamePipeLib.Utils;

--- a/GamePipe/ViewModel/TransferManagerViewModel.cs
+++ b/GamePipe/ViewModel/TransferManagerViewModel.cs
@@ -2,11 +2,7 @@
 * Copyright (c) 2016 Joseph Shaw
 * Distributed under the GNU GPL v2. For full terms see the file LICENSE.txt
 */
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
 using GamePipeLib.Model;
 
 namespace GamePipe.ViewModel

--- a/GamePipe/ViewModel/TransferViewModel.cs
+++ b/GamePipe/ViewModel/TransferViewModel.cs
@@ -3,10 +3,7 @@
 * Distributed under the GNU GPL v2. For full terms see the file LICENSE.txt
 */
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using GamePipeLib.Model;
 using GamePipeLib.Interfaces;
 

--- a/GamePipe/ViewModel/ViewModelBase.cs
+++ b/GamePipe/ViewModel/ViewModelBase.cs
@@ -3,11 +3,7 @@
 * Distributed under the GNU GPL v2. For full terms see the file LICENSE.txt
 */
 
-using Microsoft.VisualBasic;
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Data;
 using System.Diagnostics;
 using System.ComponentModel;
 

--- a/GamePipeLib/GamePipeLib.csproj
+++ b/GamePipeLib/GamePipeLib.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>GamePipeLib</RootNamespace>
     <AssemblyName>GamePipeLib</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -41,12 +42,7 @@
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
@@ -81,7 +77,9 @@
     <Compile Include="Utils\SteamWebUtils.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>

--- a/GamePipeLib/Interfaces/IAppProvider.cs
+++ b/GamePipeLib/Interfaces/IAppProvider.cs
@@ -2,14 +2,10 @@
 * Copyright (c) 2016 Joseph Shaw
 * Distributed under the GNU GPL v2. For full terms see the file LICENSE.txt
 */
-using System;
+
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.ServiceModel;
 using System.Runtime.Serialization;
-using System.ServiceModel.Description;
 using System.IO;
 
 namespace GamePipeLib.Interfaces

--- a/GamePipeLib/Interfaces/IGameTransfer.cs
+++ b/GamePipeLib/Interfaces/IGameTransfer.cs
@@ -2,11 +2,6 @@
 * Copyright (c) 2016 Joseph Shaw
 * Distributed under the GNU GPL v2. For full terms see the file LICENSE.txt
 */
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace GamePipeLib.Interfaces
 {

--- a/GamePipeLib/Interfaces/ILocalSteamApplication.cs
+++ b/GamePipeLib/Interfaces/ILocalSteamApplication.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace GamePipeLib.Interfaces
+﻿namespace GamePipeLib.Interfaces
 {
     public interface ILocalSteamApplication : ISteamApplication
     {

--- a/GamePipeLib/Interfaces/ISteamApplication.cs
+++ b/GamePipeLib/Interfaces/ISteamApplication.cs
@@ -3,11 +3,6 @@
 * Distributed under the GNU GPL v2. For full terms see the file LICENSE.txt
 */
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Runtime.Serialization;
 
 namespace GamePipeLib.Interfaces
 {

--- a/GamePipeLib/Interfaces/ITransferTarget.cs
+++ b/GamePipeLib/Interfaces/ITransferTarget.cs
@@ -2,11 +2,8 @@
 * Copyright (c) 2016 Joseph Shaw
 * Distributed under the GNU GPL v2. For full terms see the file LICENSE.txt
 */
-using System;
+
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using GamePipeLib.Utils;
 
 namespace GamePipeLib.Interfaces

--- a/GamePipeLib/Model/LocalCopy.cs
+++ b/GamePipeLib/Model/LocalCopy.cs
@@ -2,11 +2,7 @@
 * Copyright (c) 2016 Joseph Shaw
 * Distributed under the GNU GPL v2. For full terms see the file LICENSE.txt
 */
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
 using GamePipeLib.Interfaces;
 using System.IO;
 

--- a/GamePipeLib/Model/LocalMove.cs
+++ b/GamePipeLib/Model/LocalMove.cs
@@ -2,11 +2,7 @@
 * Copyright (c) 2016 Joseph Shaw
 * Distributed under the GNU GPL v2. For full terms see the file LICENSE.txt
 */
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
 using GamePipeLib.Interfaces;
 
 namespace GamePipeLib.Model

--- a/GamePipeLib/Model/NetworkCopy.cs
+++ b/GamePipeLib/Model/NetworkCopy.cs
@@ -3,10 +3,6 @@
 * Distributed under the GNU GPL v2. For full terms see the file LICENSE.txt
 */
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using GamePipeLib.Interfaces;
 using System.IO;
 

--- a/GamePipeLib/Model/NotifyPropertyChangedBase.cs
+++ b/GamePipeLib/Model/NotifyPropertyChangedBase.cs
@@ -2,12 +2,8 @@
 * Copyright (c) 2016 Joseph Shaw
 * Distributed under the GNU GPL v2. For full terms see the file LICENSE.txt
 */
-using System;
-using System.Collections.Generic;
+
 using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace GamePipeLib.Model
 {

--- a/GamePipeLib/Model/Steam/Root.cs
+++ b/GamePipeLib/Model/Steam/Root.cs
@@ -5,8 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.IO;
 using System.Text.RegularExpressions;
 using System.Collections.ObjectModel;

--- a/GamePipeLib/Model/Steam/SteamApp.cs
+++ b/GamePipeLib/Model/Steam/SteamApp.cs
@@ -3,9 +3,7 @@
 * Distributed under the GNU GPL v2. For full terms see the file LICENSE.txt
 */
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using System.IO;
 using GamePipeLib.Interfaces;

--- a/GamePipeLib/Model/Steam/SteamArchive.cs
+++ b/GamePipeLib/Model/Steam/SteamArchive.cs
@@ -5,11 +5,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.IO;
 using GamePipeLib.Utils;
-using System.IO.Compression;
 
 namespace GamePipeLib.Model.Steam
 {

--- a/GamePipeLib/Model/Steam/SteamBase.cs
+++ b/GamePipeLib/Model/Steam/SteamBase.cs
@@ -2,12 +2,6 @@
 * Copyright (c) 2016 Joseph Shaw
 * Distributed under the GNU GPL v2. For full terms see the file LICENSE.txt
 */
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.Win32;
 
 namespace GamePipeLib.Model.Steam
 {

--- a/GamePipeLib/Model/Steam/SteamBundle.cs
+++ b/GamePipeLib/Model/Steam/SteamBundle.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using GamePipeLib.Interfaces;
 
 namespace GamePipeLib.Model.Steam

--- a/GamePipeLib/Model/Steam/SteamLibrary.cs
+++ b/GamePipeLib/Model/Steam/SteamLibrary.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.IO;
-using System.Text;
 using System.Threading.Tasks;
 using GamePipeLib.Interfaces;
 using GamePipeLib.Utils;

--- a/GamePipeLib/Model/Steam/SteamUserInfo.cs
+++ b/GamePipeLib/Model/Steam/SteamUserInfo.cs
@@ -4,9 +4,6 @@
 */
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.IO;
 using System.Text.RegularExpressions;
 namespace GamePipeLib.Model.Steam

--- a/GamePipeLib/Model/TransferBase.cs
+++ b/GamePipeLib/Model/TransferBase.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using GamePipeLib.Interfaces;
 using System.IO;

--- a/GamePipeLib/Model/TransferManager.cs
+++ b/GamePipeLib/Model/TransferManager.cs
@@ -5,8 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.IO;
 using System.Threading;
 using System.Collections.ObjectModel;

--- a/GamePipeLib/Properties/AssemblyInfo.cs
+++ b/GamePipeLib/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/GamePipeLib/Utils/CrcStream.cs
+++ b/GamePipeLib/Utils/CrcStream.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using System.IO;
 
 //TODO include this in license agreement
 //Licensed under The Code Project Open License (CPOL) 1.02  http://www.codeproject.com/info/cpol10.aspx

--- a/GamePipeLib/Utils/FileUtils.cs
+++ b/GamePipeLib/Utils/FileUtils.cs
@@ -3,10 +3,8 @@
 * Distributed under the GNU GPL v2. For full terms see the file LICENSE.txt
 */
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using System.IO;
 using System.IO.Compression;
 namespace GamePipeLib.Utils

--- a/GamePipeLib/Utils/Logging.cs
+++ b/GamePipeLib/Utils/Logging.cs
@@ -2,11 +2,7 @@
 * Copyright (c) 2016 Joseph Shaw
 * Distributed under the GNU GPL v2. For full terms see the file LICENSE.txt
 */
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
 using log4net;
 
 [assembly: log4net.Config.XmlConfigurator(Watch = false)]

--- a/GamePipeLib/Utils/SteamDirParsingUtils.cs
+++ b/GamePipeLib/Utils/SteamDirParsingUtils.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using System.Text.RegularExpressions;
 using System.IO;
 

--- a/GamePipeLib/Utils/SteamWebUtils.cs
+++ b/GamePipeLib/Utils/SteamWebUtils.cs
@@ -7,8 +7,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.IO;
 using System.Text.RegularExpressions;
 

--- a/GamePipeLib/app.config
+++ b/GamePipeLib/app.config
@@ -1,11 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <configSections>
-        <sectionGroup name="applicationSettings" type="System.Configuration.ApplicationSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
-            <section name="GamePipeLib.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+        <sectionGroup name="applicationSettings" type="System.Configuration.ApplicationSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+            <section name="GamePipeLib.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
         </sectionGroup>
-        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
-            <section name="GamePipeLib.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+            <section name="GamePipeLib.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false"/>
         </sectionGroup>
     </configSections>
     <applicationSettings>
@@ -24,8 +24,8 @@
                 <value>False</value>
             </setting>
             <setting name="ManualSteamDir" serializeAs="String">
-                <value />
+                <value/>
             </setting>
         </GamePipeLib.Properties.Settings>
     </userSettings>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>

--- a/GamePipeService/App.config
+++ b/GamePipeService/App.config
@@ -1,30 +1,29 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
   </startup>
   <appSettings>
-    <add key="aspnet:UseTaskFriendlySynchronizationContext" value="true" />
+    <add key="aspnet:UseTaskFriendlySynchronizationContext" value="true"/>
   </appSettings>
   <system.web>
-    <compilation debug="true" />
+    <compilation debug="true"/>
   </system.web>
   <!-- When deploying the service library project, the content of the config file must be added to the host's 
   app.config file. System.Configuration does not support config files for libraries. -->
   <system.serviceModel>
     <services>
       <service name="GamePipeService.GameProviderService">
-        <endpoint address="" binding="netTcpBinding" bindingConfiguration="StreamedBinding"
-          name="InfoProvider" contract="GamePipeLib.Interfaces.IAppProvider">
+        <endpoint address="" binding="netTcpBinding" bindingConfiguration="StreamedBinding" name="InfoProvider" contract="GamePipeLib.Interfaces.IAppProvider">
           <identity>
-            <dns value="localhost" />
+            <dns value="localhost"/>
           </identity>
         </endpoint>
-        <endpoint address="mex" binding="mexHttpBinding" contract="IMetadataExchange" />
+        <endpoint address="mex" binding="mexHttpBinding" contract="IMetadataExchange"/>
         <host>
           <baseAddresses>
-            <add baseAddress="http://localhost:8733/Design_Time_Addresses/GamePipeService/SampleService/" />
-            <add baseAddress="net.tcp://localhost:41650/gamepipe/" />
+            <add baseAddress="http://localhost:8733/Design_Time_Addresses/GamePipeService/SampleService/"/>
+            <add baseAddress="net.tcp://localhost:41650/gamepipe/"/>
           </baseAddresses>
         </host>
       </service>
@@ -38,19 +37,17 @@
           <!-- To receive exception details in faults for debugging purposes, 
           set the value below to true.  Set to false before deployment 
           to avoid disclosing exception information -->
-          <serviceDebug includeExceptionDetailInFaults="False" />
+          <serviceDebug includeExceptionDetailInFaults="False"/>
         </behavior>
       </serviceBehaviors>
     </behaviors>
     <bindings>
       <netTcpBinding>
-        <binding name="StreamedBinding" receiveTimeout="10:10:00" sendTimeout="10:10:00"
-          transferMode="Streamed"  maxReceivedMessageSize="9223372036854775807" maxBufferSize="16777215">
-          <security mode="None" />
+        <binding name="StreamedBinding" receiveTimeout="10:10:00" sendTimeout="10:10:00" transferMode="Streamed" maxReceivedMessageSize="9223372036854775807" maxBufferSize="16777215">
+          <security mode="None"/>
         </binding>
-        <binding receiveTimeout="10:10:00" sendTimeout="10:10:00" transferMode="Streamed"
-           maxReceivedMessageSize="9223372036854775807" maxBufferSize="16777215">
-          <security mode="None" />
+        <binding receiveTimeout="10:10:00" sendTimeout="10:10:00" transferMode="Streamed" maxReceivedMessageSize="9223372036854775807" maxBufferSize="16777215">
+          <security mode="None"/>
         </binding>
       </netTcpBinding>
     </bindings>

--- a/GamePipeService/GamePipeService.csproj
+++ b/GamePipeService/GamePipeService.csproj
@@ -13,9 +13,10 @@
     <AssemblyName>GamePipeService</AssemblyName>
     <ProjectTypeGuids>{3D9AD99F-2412-4246-B90B-4EAA41C64699};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <StartArguments>/client:"WcfTestClient.exe"</StartArguments>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <WcfConfigValidationEnabled>True</WcfConfigValidationEnabled>
     <XsdCodeGenEnabled>True</XsdCodeGenEnabled>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -35,18 +36,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\packages\log4net.2.0.5\lib\net45-full\log4net.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="GameProviderService.cs" />

--- a/GamePipeService/GameProviderService.cs
+++ b/GamePipeService/GameProviderService.cs
@@ -5,9 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Threading;
 using System.IO;
 using GamePipeLib.Utils;
 using GamePipeLib.Model.Steam;

--- a/GamePipeService/IDiscoverFriends.cs
+++ b/GamePipeService/IDiscoverFriends.cs
@@ -2,13 +2,8 @@
 * Copyright (c) 2016 Joseph Shaw
 * Distributed under the GNU GPL v2. For full terms see the file LICENSE.txt
 */
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
 using System.ServiceModel;
-using System.ServiceModel.Description;
 
 namespace GamePipeService
 {

--- a/GamePipeService/Properties/AssemblyInfo.cs
+++ b/GamePipeService/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 


### PR DESCRIPTION
By upgrading from .NET 4.5.2 to .NET 4.6.1 you get a small perf bump from the runtime, and only exclude Vista (See [here](https://msdn.microsoft.com/en-us/library/8z6watww%28v=vs.110%29.aspx?f=255&MSPPError=-2147217396) for supported .NET versions on Windows). There's approximately 10% lower RAM usage on my system.

Also, removing unused usings is just tidying more than anything else.
